### PR TITLE
chore: sync develop with main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy client/dist --project-name=qraft --branch main
+          command: pages deploy client/dist --project-name=qraft-ultimate --branch main
 
       - name: Deploy to Staging (Pages)
         if: github.ref == 'refs/heads/develop'
@@ -79,4 +79,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy client/dist --project-name=qraft --branch develop
+          command: pages deploy client/dist --project-name=qraft-ultimate --branch develop

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -1,4 +1,4 @@
-name = "qraft"
+name = "qraft-ultimate"
 main = "index.ts"
 compatibility_date = "2024-11-25"
 compatibility_flags = [ "nodejs_compat" ]
@@ -6,7 +6,7 @@ compatibility_flags = [ "nodejs_compat" ]
 [vars]
 GOOGLE_CLIENT_ID = "your-google-client-id.apps.googleusercontent.com"
 SESSION_SECRET = "generate-a-long-random-string-here"
-FRONTEND_URL = "https://qraft.pages.dev"
+FRONTEND_URL = "https://qraft-ultimate.pages.dev"
 
 [[d1_databases]]
 binding = "DB"
@@ -16,10 +16,10 @@ migrations_dir = "drizzle"
 
 # ===== Staging Environment =====
 [env.staging]
-name = "qraft-staging"
+name = "qraft-ultimate-staging"
 
 [env.staging.vars]
-FRONTEND_URL = "https://develop.qraft.pages.dev"
+FRONTEND_URL = "https://develop.qraft-ultimate.pages.dev"
 
 [[env.staging.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

- mainに入っている `chore: rename projects to qraft-ultimate (#62)` をdevelopに取り込む
- develop と main のブランチ差異を解消する

## 変更内容

- mainより2コミット遅れていたdevelopを同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)